### PR TITLE
Advantageカードのレイアウト調整

### DIFF
--- a/src/components/footer/_components/Company.astro
+++ b/src/components/footer/_components/Company.astro
@@ -14,7 +14,7 @@ import {companyInfo} from "../../../constants/about/companyInfo"
             <tr>
                 <th class="info-label">お問合せ</th>
                 <td class="info-data">
-                    <a href="http://forms.gle/xMnkoDKphxXM8ZY48">お問合せフォーム</a>
+                    <a href="http://forms.gle/xMnkoDKphxXM8ZY48" target="_blank" rel="noopener noreferrer">お問合せフォーム</a>
                 </td>
             </tr>
         </tbody>

--- a/src/components/parts/card/AdvantageCard.astro
+++ b/src/components/parts/card/AdvantageCard.astro
@@ -39,7 +39,7 @@ const props: Props = Astro.props
 
         .description-area {
             padding: 20px 30px;
-            min-height: 182px;
+            min-height: 140px;
             border-bottom-left-radius: 20px;
             border-bottom-right-radius: 20px;
             background: linear-gradient(to right, #002D5E, #004298);
@@ -55,7 +55,10 @@ const props: Props = Astro.props
     @include max("tab"){
         .photo-card {
             .description-area {
-                min-height: 128px;
+                padding: 20px;
+                .card-title {
+                    padding-bottom: 10px;
+                }
             }
         }
     }


### PR DESCRIPTION
## 背景
- Advantage カードの説明文部分の余白が多い

## 修正内容
- min-height と余白を修正
- お問合せのリンクをtarget blank に変更