### PR TITLE
fix:kvのコピー位置の修正

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -31,6 +31,8 @@ import Image from 'astro/components/Image.astro';
         > .general-logo {
             position: absolute;
             bottom: 0;
+            width: 50vw;
+            max-width: 862px;
         }
         &::after {
             position: absolute;
@@ -58,8 +60,8 @@ import Image from 'astro/components/Image.astro';
         position: absolute;
     	font-size: 30px;
 		font-weight: 900;
-		    top: 198px;
-		    left: 10vw;
+		    top: clamp(100px, 20vw, 198px);
+		    left: clamp(150px, 10vw, 168px);
 		    letter-spacing: 5px;
 		    color: #001d41;
 		    > span {


### PR DESCRIPTION
## 背景
KVの高さは固定ではなくブラウザサイズにより可変

## 修正内容
- KVの高さは固定ではなくブラウザサイズにより可変とする
- コピーの位置をKVのサイズに合わせて可変にする
- ロゴのサイズをKVのサイズに合わせて可変にする