### PR TITLE
fix:htmlの言語設定を日本語にする

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,7 +4,7 @@ import GeneralOGPImage from "@/assets/ogp/OGP.jpg";
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <!-- Google Tag Manager -->
     <script>


### PR DESCRIPTION
## 背景
- 言語設定がenになっているため、Android で翻訳が起動する

## 修正内容
- 言語設定をjaに変更